### PR TITLE
Changes in credits (level->qualificationLevel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ These changes are NOT officially released yet.
 * Some more predefined identifier types were mentioned - the ones used in the
   EWP (Erasmus Without Paper) project.
 
+* Changes in `<credit>` subelements: The `<level>` element is now DEPRECATED
+  in favor of the newly introduced `<qualificationLevel type="eqf">` element.
+
 
 Version 1.1.0
 -------------

--- a/example.xml
+++ b/example.xml
@@ -89,6 +89,7 @@ Server implementers can add line breaks (or double line breaks) within this elem
                         <level>Bachelor</level> <!-- level is optional! -->
                         <value>6</value>
                     </credit>
+                    <qualificationLevel type="eqf">5</qualificationLevel>
                     <languageOfInstruction>pl</languageOfInstruction>
                 </learningOpportunityInstance>
             </specifies>

--- a/schema.xsd
+++ b/schema.xsd
@@ -1090,6 +1090,15 @@
                                                     </xs:annotation>
                                                 </xs:element>
                                                 <xs:element name="level" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            DEPRECATED. Please use the `qualificationLevel` element instead!
+
+                                                            This is a non-standard identifier of the qualification level for this credit.
+                                                            The values allowed for this element were limited, so it has been replaced by
+                                                            the new `qualificationLevel` element instead.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
                                                     <xs:simpleType>
                                                         <xs:restriction base="xs:token">
                                                             <xs:enumeration value="Bachelor"/>
@@ -1097,6 +1106,38 @@
                                                             <xs:enumeration value="PhD"/>
                                                         </xs:restriction>
                                                     </xs:simpleType>
+                                                </xs:element>
+                                                <xs:element name="qualificationLevel" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Set of identifiers of the qualification level for this credit.
+
+                                                            There should be at most one `qualificationLevel` value for each type.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:simpleContent>
+                                                            <xs:restriction base="xs:token">
+                                                                <xs:attribute name="type" type="xs:token" use="required">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            The type of qualification level identifier.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:attribute>
+                                                                <xs:enumeration value="eqf">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Standard EQF study level identifier. If this type is chosen, then the value
+                                                                            MUST be an integer in the 1-8 scale, as described here:
+
+                                                                            https://en.wikipedia.org/wiki/European_Qualifications_Framework
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:enumeration>
+                                                            </xs:restriction>
+                                                        </xs:simpleContent>
+                                                    </xs:complexType>
                                                 </xs:element>
                                                 <xs:element name="value" type="xs:decimal" minOccurs="0">
                                                     <xs:annotation>

--- a/schema.xsd
+++ b/schema.xsd
@@ -1122,6 +1122,8 @@
                                                                     <xs:annotation>
                                                                         <xs:documentation>
                                                                             The type of qualification level identifier.
+
+                                                                            More types MAY be added in the future. You SHOULD be ready for that.
                                                                         </xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:attribute>


### PR DESCRIPTION
The `level` element is deprecated in favor of the newly introduced
`qualificationLevel`.

https://github.com/emrex-eu/elmo-schemas/issues/26