### PR TITLE
[ELMO-65] Address as identifier

### DIFF
--- a/schema.xsd
+++ b/schema.xsd
@@ -1,18 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema elementFormDefault="qualified" targetNamespace="https://github.com/emrex-eu/elmo-schemas/tree/v1"
-    xmlns="https://github.com/emrex-eu/elmo-schemas/tree/v1"
-    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-    xmlns:europass="http://europass.cedefop.europa.eu/Europass/V2.0"
-    xmlns:xml="http://www.w3.org/XML/1998/namespace"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:ewpAddress="https://github.com/erasmus-without-paper/ewp-specs-types-address/tree/stable-v1"
-    >
-    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="https://raw.githubusercontent.com/emrex-eu/elmo-schemas/v1/references/xmldsig-core-schema.xsd"/>
-    <xs:import namespace="http://europass.cedefop.europa.eu/Europass/V2.0" schemaLocation="https://raw.githubusercontent.com/emrex-eu/elmo-schemas/v1/references/EUROPASS_ISOCountries_V1.1.xsd"/>
-    <xs:import namespace="https://github.com/erasmus-without-paper/ewp-specs-types-address/tree/stable-v1" schemaLocation="https://raw.githubusercontent.com/erasmus-without-paper/ewp-specs-types-address/stable-v1/schema.xsd"/>
-    <xs:annotation>
-        <xs:documentation>This schema describes the EMREX ELMO XML format, used for formatting students'
+<xs:schema elementFormDefault="qualified" targetNamespace="https://github.com/emrex-eu/elmo-schemas/tree/v1" xmlns="https://github.com/emrex-eu/elmo-schemas/tree/v1" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:europass="http://europass.cedefop.europa.eu/Europass/V2.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ewpAddress="https://github.com/erasmus-without-paper/ewp-specs-types-address/tree/stable-v1">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="https://raw.githubusercontent.com/emrex-eu/elmo-schemas/v1/references/xmldsig-core-schema.xsd" />
+  <xs:import namespace="http://europass.cedefop.europa.eu/Europass/V2.0" schemaLocation="https://raw.githubusercontent.com/emrex-eu/elmo-schemas/v1/references/EUROPASS_ISOCountries_V1.1.xsd" />
+  <xs:import namespace="https://github.com/erasmus-without-paper/ewp-specs-types-address/tree/stable-v1" schemaLocation="https://raw.githubusercontent.com/erasmus-without-paper/ewp-specs-types-address/stable-v1/schema.xsd" />
+  <xs:annotation>
+    <xs:documentation>This schema describes the EMREX ELMO XML format, used for formatting students'
             Transcripts of Records.
 
             This format was first used for formatting content returned in EMREX NCP
@@ -166,40 +159,40 @@
 
             https://github.com/blog/1508-repository-redirects-are-here
         </xs:documentation>
-    </xs:annotation>
-    <!-- The root element -->
-    <xs:element name="elmo">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="generatedDate" type="xs:dateTime">
-                    <xs:annotation>
-                        <xs:documentation>The datetime when the file was generated. It SHOULD contain the timezone
+  </xs:annotation>
+  <!-- The root element -->
+  <xs:element name="elmo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="generatedDate" type="xs:dateTime">
+          <xs:annotation>
+            <xs:documentation>The datetime when the file was generated. It SHOULD contain the timezone
                             suffix. Example values: &quot;2015-08-01T12:00:00+02:00&quot;, &quot;2015-08-01T10:00:00Z&quot;.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element name="learner">
-                    <xs:annotation>
-                        <xs:documentation>This describes the student whose achievements we will be describing. One EMREX
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="learner">
+          <xs:annotation>
+            <xs:documentation>This describes the student whose achievements we will be describing. One EMREX
                             ELMO element may contain multiple reports, but all of the reports are always
                             describing exactly one student.
                         </xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element minOccurs="0" name="citizenship" type="europass:countryCode">
-                                <xs:annotation>
-                                    <xs:documentation>The ISO 3166-1-alpha-2 code of the country the student is a citizen of.
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="0" name="citizenship" type="europass:countryCode">
+                <xs:annotation>
+                  <xs:documentation>The ISO 3166-1-alpha-2 code of the country the student is a citizen of.
                                         E.g. &quot;PL&quot;.
 
                                         For server implementers: If this is not known then you MUST skip the element
                                         altogether (instead of, for example, providing an empty value).
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element maxOccurs="unbounded" minOccurs="0" name="identifier">
-                                <xs:annotation>
-                                    <xs:documentation>For server implementers: Please read thought the list of predefined identifier
+                </xs:annotation>
+              </xs:element>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="identifier">
+                <xs:annotation>
+                  <xs:documentation>For server implementers: Please read thought the list of predefined identifier
                                         types below and try to provide all of those you can get. We are aware that
                                         some of those will be difficult to get (especially for the foreign students).
 
@@ -207,13 +200,13 @@
                                         it for any purpose you want. However, you should expect them to be NOT present
                                         most of the times.
                                     </xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:simpleContent>
-                                        <xs:extension base="xs:token">
-                                            <xs:attribute name="type" type="xs:token" use="required">
-                                                <xs:annotation>
-                                                    <xs:documentation>Currently there are only a few predefined types you can have here:
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:token">
+                      <xs:attribute name="type" type="xs:token" use="required">
+                        <xs:annotation>
+                          <xs:documentation>Currently there are only a few predefined types you can have here:
 
                                                         nationalIdentifier - if present, then the value of it should contain the
                                                             &quot;primary&quot; national identifier of the student. For more information on
@@ -226,29 +219,29 @@
                                                         You can also have any number of custom types. Contact us if you'd like
                                                         them added to the official specs.
                                                     </xs:documentation>
-                                                </xs:annotation>
-                                            </xs:attribute>
-                                        </xs:extension>
-                                    </xs:simpleContent>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element name="givenNames" type="xs:token">
-                                <xs:annotation>
-                                    <xs:documentation>The given names of the student. All servers MUST provide it (if it is impossible
+                        </xs:annotation>
+                      </xs:attribute>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="givenNames" type="xs:token">
+                <xs:annotation>
+                  <xs:documentation>The given names of the student. All servers MUST provide it (if it is impossible
                                         for some reason, please provide an empty string here).
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="familyName" type="xs:token">
-                                <xs:annotation>
-                                    <xs:documentation>The family name of the student. All servers MUST provide it (if it is impossible
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="familyName" type="xs:token">
+                <xs:annotation>
+                  <xs:documentation>The family name of the student. All servers MUST provide it (if it is impossible
                                         for some reason, please provide an empty string here).
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element minOccurs="0" name="bday" type="xs:date">
-                                <xs:annotation>
-                                    <xs:documentation>For server implementers: The birth date is vital to EMREX and SHOULD be provided.
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" name="bday" type="xs:date">
+                <xs:annotation>
+                  <xs:documentation>For server implementers: The birth date is vital to EMREX and SHOULD be provided.
                                         If you cannot provide it, you MUST skip the bday element altogether.
 
                                         For client implementers:
@@ -260,111 +253,111 @@
                                           you to identify such student automatically within your system. Please consult
                                           EMREX documentation for more information.
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element minOccurs="0" maxOccurs="1" name="placeOfBirth" type="xs:token">
-                                <xs:annotation>
-                                    <xs:documentation>The student's place of birth.
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="placeOfBirth" type="xs:token">
+                <xs:annotation>
+                  <xs:documentation>The student's place of birth.
 
                                         For server implementers: If this is not known then you MUST skip the element
                                         altogether (instead of, for example, providing an empty value).
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element minOccurs="0" maxOccurs="1" name="birthName" type="xs:token">
-                                <xs:annotation>
-                                    <xs:documentation>First name(s) and family name(s) of the student at birth, described as a single text value. 
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="birthName" type="xs:token">
+                <xs:annotation>
+                  <xs:documentation>First name(s) and family name(s) of the student at birth, described as a single text value. 
 
                                         For server implementers: If this is not known then you MUST skip the element
                                         altogether (instead of, for example, providing an empty value).
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element minOccurs="0" maxOccurs="1" name="currentAddress" type="ewpAddress:FlexibleAddress">
-                                <xs:annotation>
-                                    <xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="currentAddress" type="ewpAddress:FlexibleAddress">
+                <xs:annotation>
+                  <xs:documentation>
                                         The student's current physical address.  This is the address which should work when, for example,
                                         the user pastes it (without the recipientName part) into Google Maps.
 
                                         This element has been described in detail in Erasmus Without Paper:
                                         https://github.com/erasmus-without-paper/ewp-specs-types-address
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element minOccurs="0" maxOccurs="1" name="gender">
-                                <xs:annotation>
-                                    <xs:documentation>ISO/IEC 5218 code of human gender.
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="gender">
+                <xs:annotation>
+                  <xs:documentation>ISO/IEC 5218 code of human gender.
 
                                         https://en.wikipedia.org/wiki/ISO/IEC_5218
                                     </xs:documentation>
-                                </xs:annotation>
-                                <xs:simpleType>
-                                    <xs:restriction base="xs:integer">
-                                        <xs:enumeration value="0">
-                                            <xs:annotation>
-                                                <xs:documentation>Unknown - the gender of the person has not been recorded.</xs:documentation>
-                                            </xs:annotation>
-                                        </xs:enumeration>
-                                        <xs:enumeration value="1">
-                                            <xs:annotation>
-                                                <xs:documentation>Male</xs:documentation>
-                                            </xs:annotation>
-                                        </xs:enumeration>
-                                        <xs:enumeration value="2">
-                                            <xs:annotation>
-                                                <xs:documentation>Female</xs:documentation>
-                                            </xs:annotation>
-                                        </xs:enumeration>
-                                        <xs:enumeration value="9">
-                                            <xs:annotation>
-                                                <xs:documentation>Not Applicable - indeterminate, i.e. unable to be classified as either male or female</xs:documentation>
-                                            </xs:annotation>
-                                        </xs:enumeration>
-                                    </xs:restriction>
-                                </xs:simpleType>
-                            </xs:element>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element maxOccurs="unbounded" minOccurs="1" name="report">
-                    <xs:annotation>
-                        <xs:documentation>Responses MUST contain at least one report.
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:integer">
+                    <xs:enumeration value="0">
+                      <xs:annotation>
+                        <xs:documentation>Unknown - the gender of the person has not been recorded.</xs:documentation>
+                      </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="1">
+                      <xs:annotation>
+                        <xs:documentation>Male</xs:documentation>
+                      </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="2">
+                      <xs:annotation>
+                        <xs:documentation>Female</xs:documentation>
+                      </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="9">
+                      <xs:annotation>
+                        <xs:documentation>Not Applicable - indeterminate, i.e. unable to be classified as either male or female</xs:documentation>
+                      </xs:annotation>
+                    </xs:enumeration>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element maxOccurs="unbounded" minOccurs="1" name="report">
+          <xs:annotation>
+            <xs:documentation>Responses MUST contain at least one report.
 
                             Please note, that one response may contain multiple reports, issued by
                             different institutions. All of those reports MUST be issued for the same
                             student though (that's why the learner element is placed outside of the
                             report element).
                         </xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:annotation>
-                            <xs:documentation>This describes an institution (issuer) and a *subset* of courses *completed*
+          </xs:annotation>
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>This describes an institution (issuer) and a *subset* of courses *completed*
                                 by the student within this institution.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:sequence>
-                            <xs:element name="issuer">
-                                <xs:annotation>
-                                    <xs:documentation>This element identifies the host institution - the institution at which the
+            </xs:annotation>
+            <xs:sequence>
+              <xs:element name="issuer">
+                <xs:annotation>
+                  <xs:documentation>This element identifies the host institution - the institution at which the
                                         student has studied in order to achieve the credits described in this report).
 
                                         Note for server implementers: If your data comes from multiple institutions then
                                         you MUST put it inside separate report elements.
                                     </xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element minOccurs="0" name="country" type="europass:countryCode">
-                                            <xs:annotation>
-                                                <xs:documentation>An ISO 3166-1-alpha-2 code of the country in which the institution is
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element minOccurs="0" name="country" type="europass:countryCode">
+                      <xs:annotation>
+                        <xs:documentation>An ISO 3166-1-alpha-2 code of the country in which the institution is
                                                     operating. If the country is not known, or the institution is an international
                                                     one, then this element MUST NOT be present.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:element>
-                                        <xs:element maxOccurs="unbounded" minOccurs="1" name="identifier">
-                                            <xs:annotation>
-                                                <xs:documentation>For server implementers: You MUST be able to provide at least one identifier of
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element maxOccurs="unbounded" minOccurs="1" name="identifier">
+                      <xs:annotation>
+                        <xs:documentation>For server implementers: You MUST be able to provide at least one identifier of
                                                     the institution. You SHOULD provide all of them, if you can.
 
                                                     Please note, that you might be able to generate SCHAC identifiers by yourself,
@@ -373,13 +366,13 @@
                                                     identifiers may change in time (e.g. after institutions are merged), but you
                                                     should use your best guess nonetheless.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                            <xs:complexType>
-                                                <xs:simpleContent>
-                                                    <xs:extension base="xs:token">
-                                                        <xs:attribute name="type" type="xs:token" use="required">
-                                                            <xs:annotation>
-                                                                <xs:documentation>These are the currently supported predefined types:
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:token">
+                            <xs:attribute name="type" type="xs:token" use="required">
+                              <xs:annotation>
+                                <xs:documentation>These are the currently supported predefined types:
 
                                                                     pic - the PIC code,
                                                                     erasmus - the ERASMUS code,
@@ -387,18 +380,19 @@
                                                                         in other EU projects too, in particular the EWP (Erasmus Without Paper)
                                                                         project. See here:
                                                                         https://github.com/erasmus-without-paper/ewp-specs-api-registry/#schac-identifiers
+                                                                    address - full address of the institution (e.g. streetName 1, postNumber, city, state, country)
 
                                                                     You can also have any number of custom types.
                                                                 </xs:documentation>
-                                                            </xs:annotation>
-                                                        </xs:attribute>
-                                                    </xs:extension>
-                                                </xs:simpleContent>
-                                            </xs:complexType>
-                                        </xs:element>
-                                        <xs:element maxOccurs="unbounded" minOccurs="1" name="title" type="TokenWithOptionalLang">
-                                            <xs:annotation>
-                                                <xs:documentation>The name of the institution. May be provided in multiple languages. At least
+                              </xs:annotation>
+                            </xs:attribute>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element maxOccurs="unbounded" minOccurs="1" name="title" type="TokenWithOptionalLang">
+                      <xs:annotation>
+                        <xs:documentation>The name of the institution. May be provided in multiple languages. At least
                                                     one name is required.
 
                                                     For server implementers:
@@ -410,23 +404,23 @@
                                                     - You SHOULD try to include the name of the institution both in English and
                                                       in the original language.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:element>
-                                        <xs:element name="url" type="xs:token">
-                                            <xs:annotation>
-                                                <xs:documentation>The URL of the intitution's web page. It is a required element, because it
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="url" type="xs:token">
+                      <xs:annotation>
+                        <xs:documentation>The URL of the intitution's web page. It is a required element, because it
                                                     should be easy to acquire it on server's side, and it might be used as a last
                                                     resort when attempting to pinpoint the issuing institution on the EMREX
                                                     Client's side.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:element>
-                                    </xs:sequence>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element maxOccurs="unbounded" minOccurs="0" name="learningOpportunitySpecification" type="LearningOpportunitySpecification">
-                                <xs:annotation>
-                                    <xs:documentation>Please consult the documentation on the LearningOpportunitySpecification type.
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="learningOpportunitySpecification" type="LearningOpportunitySpecification">
+                <xs:annotation>
+                  <xs:documentation>Please consult the documentation on the LearningOpportunitySpecification type.
 
                                         Additional note for client implementers:
 
@@ -436,11 +430,11 @@
                                         error, and it should NOT trigger the &quot;manual verification&quot; process on your
                                         part (you might want to show a warning though).
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="issueDate" type="xs:dateTime">
-                                <xs:annotation>
-                                    <xs:documentation>The datetime when the report has been issued. It SHOULD contain the timezone
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="issueDate" type="xs:dateTime">
+                <xs:annotation>
+                  <xs:documentation>The datetime when the report has been issued. It SHOULD contain the timezone
                                         suffix. Example values: &quot;2015-08-01T12:00:00+02:00&quot;, &quot;2015-08-01T10:00:00Z&quot;.
 
                                         Since EMREX ELMO may contain multiple reports, the issuing dates of each of
@@ -449,11 +443,11 @@
                                         For most server implementations though, all issueDates will be the same as the
                                         generatedDate included in the file header.
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element maxOccurs="unbounded" minOccurs="0" name="gradingScheme">
-                                <xs:annotation>
-                                    <xs:documentation>These elements describe all grading schemes which were used in other sections
+                </xs:annotation>
+              </xs:element>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="gradingScheme">
+                <xs:annotation>
+                  <xs:documentation>These elements describe all grading schemes which were used in other sections
                                         of the report. Elements in this set can be referenced by their identifiers.
 
                                         Note, that this list may contain local grading schemes, which are not
@@ -468,89 +462,89 @@
                                         is &quot;local only&quot;. In particular, popular grading schemes (like ECTS) can also be
                                         listed here, but they cannot be easily identified.
                                     </xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
-                                            <xs:annotation>
-                                                <xs:documentation>A set of descriptions (in multiple languages). It is RECOMMENDED to include a
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
+                      <xs:annotation>
+                        <xs:documentation>A set of descriptions (in multiple languages). It is RECOMMENDED to include a
                                                     description, at least in English.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:element>
-                                    </xs:sequence>
-                                    <xs:attribute name="localId" type="xs:token" use="required">
-                                        <xs:annotation>
-                                            <xs:documentation>Local identifier, provided by the institution which has generated this report.
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="localId" type="xs:token" use="required">
+                    <xs:annotation>
+                      <xs:documentation>Local identifier, provided by the institution which has generated this report.
                                                 This identifier is used to reference `gradingScheme` elements from other places
                                                 in this document, and as such, is guaranteed to be valid only within this
                                                 single document. This means that it can even be dynamically generated, just for
                                                 the purpose of sticking with the format of this document. Clients SHOULD NOT
                                                 store this identifier.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:attribute>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element maxOccurs="unbounded" minOccurs="0" name="attachment" type="Attachment">
-                                <xs:annotation>
-                                    <xs:documentation>Please note that attachments can be included in multiple places. This is the
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="attachment" type="Attachment">
+                <xs:annotation>
+                  <xs:documentation>Please note that attachments can be included in multiple places. This is the
                                         place for those attachments which are related to a *single institution*.
 
                                         Read the description of the Attachment type for further information.
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="attachment" type="Attachment">
-                    <xs:annotation>
-                        <xs:documentation>Please note that attachments can be included in multiple places. This is the
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element maxOccurs="unbounded" minOccurs="0" name="attachment" type="Attachment">
+          <xs:annotation>
+            <xs:documentation>Please note that attachments can be included in multiple places. This is the
                             place for those attachments which are *either unrelated to any institution, or
                             are related to multiple institutions*.
 
                             Read the description of the Attachment type for further information.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element maxOccurs="1" minOccurs="0" name="groups" type="Groups">
-                    <xs:annotation>
-                        <xs:documentation>Groups...
+          </xs:annotation>
+        </xs:element>
+        <xs:element maxOccurs="1" minOccurs="0" name="groups" type="Groups">
+          <xs:annotation>
+            <xs:documentation>Groups...
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer"/>
-                <xs:element minOccurs="0" maxOccurs="1" ref="ds:Signature">
-                    <xs:annotation>
-                        <xs:documentation>Every EMREX ELMO element MUST be signed with xmldsig-core2 enveloped signature. The
+          </xs:annotation>
+        </xs:element>
+        <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer" />
+        <xs:element minOccurs="0" maxOccurs="1" ref="ds:Signature">
+          <xs:annotation>
+            <xs:documentation>Every EMREX ELMO element MUST be signed with xmldsig-core2 enveloped signature. The
                             ds:SignedInfo element MUST contain a single ds:Reference with an empty URI. The
                             key used by the server for signing must often match some external criteria, which
                             are NOT documented here. (E.g. If you're implementing EMREX NCP, then the certificate
                             used must match the one previously published in EMREG for your NCP.) The ds:Signature
                             element SHOULD contain the copy of the its certficate in the ds:KeyInfo element.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <!-- Common types with simple content. -->
-    <xs:complexType name="TokenWithOptionalLang">
-        <xs:annotation>
-            <xs:documentation>A xs:token value with at optional xml:lang attribute. It is used in places
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- Common types with simple content. -->
+  <xs:complexType name="TokenWithOptionalLang">
+    <xs:annotation>
+      <xs:documentation>A xs:token value with at optional xml:lang attribute. It is used in places
                 where server developers may provide the name of an entity in multiple languages.
             </xs:documentation>
-        </xs:annotation>
-        <xs:simpleContent>
-            <xs:extension base="xs:token">
-                <xs:attribute ref="xml:lang" use="optional"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="PlaintextMultilineStringWithOptionalLang">
-        <xs:annotation>
-            <xs:documentation>This is very similar to TokenWithOptionalLang, but it inherits from xs:string
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attribute ref="xml:lang" use="optional" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="PlaintextMultilineStringWithOptionalLang">
+    <xs:annotation>
+      <xs:documentation>This is very similar to TokenWithOptionalLang, but it inherits from xs:string
                 (instead of xs:token), and it MAY contain basic whitespace formatting, such
                 as line breaks and double line breaks (for spliting paragraphs). The values
                 still must be in plain text though (no HTML is allowed).
@@ -561,16 +555,16 @@
                 SHOULD make sure that the end user will see the line breaks in the right
                 places. E.g. use your equivalent of the well known `nl2br` function.
             </xs:documentation>
-        </xs:annotation>
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute ref="xml:lang" use="optional"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="SimpleHtmlStringWithOptionalLang">
-        <xs:annotation>
-            <xs:documentation>&quot;Simple&quot; (but still dangerous) HTML string. This type is very different from
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang" use="optional" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="SimpleHtmlStringWithOptionalLang">
+    <xs:annotation>
+      <xs:documentation>&quot;Simple&quot; (but still dangerous) HTML string. This type is very different from
                 PlaintextMultilineStringWithOptionalLang, because it contains HTML, not
                 plain-text.
 
@@ -605,17 +599,17 @@
                 paragraphs). You may however attempt to detect and fix HTML errors, if this
                 HTML seems broken.
             </xs:documentation>
-        </xs:annotation>
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute ref="xml:lang" use="optional"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <!-- Common types with complex content. -->
-    <xs:complexType name="CustomExtensionsContainer">
-        <xs:annotation>
-            <xs:documentation>This is the type of &quot;extension&quot; elements. Extension elements may contain any
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang" use="optional" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- Common types with complex content. -->
+  <xs:complexType name="CustomExtensionsContainer">
+    <xs:annotation>
+      <xs:documentation>This is the type of &quot;extension&quot; elements. Extension elements may contain any
                 elements, as long as they are from a different namespace. Server implementers may
                 use them to include additional metadata in various places of the XML document.
                 The content of such extensions is not documented within this schema.
@@ -626,41 +620,41 @@
                 contact EMREX representative and/or the current owner of the
                 https://github.com/emrex-eu/elmo-schemas/ repository.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
-        </xs:sequence>
-        <xs:anyAttribute/>
-    </xs:complexType>
-    <xs:complexType name="Groups">
-        <xs:annotation>
-            <xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax" />
+    </xs:sequence>
+    <xs:anyAttribute />
+  </xs:complexType>
+  <xs:complexType name="Groups">
+    <xs:annotation>
+      <xs:documentation>
                 Groups is a way of organizing and sorting over groups of LOI's.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="groupType">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="title" type="TokenWithOptionalLang" maxOccurs="unbounded"/>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="group">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="title" type="TokenWithOptionalLang" maxOccurs="unbounded"/>
-                                </xs:sequence>
-                                <xs:attribute name="id" type="xs:string" use="optional"/>
-                                <xs:attribute name="sortingKey" type="xs:string" use="optional"/>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                    <xs:attribute name="id" type="xs:string" use="optional"/>
-                </xs:complexType>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="groupType">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="title" type="TokenWithOptionalLang" maxOccurs="unbounded" />
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="group">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="title" type="TokenWithOptionalLang" maxOccurs="unbounded" />
+                </xs:sequence>
+                <xs:attribute name="id" type="xs:string" use="optional" />
+                <xs:attribute name="sortingKey" type="xs:string" use="optional" />
+              </xs:complexType>
             </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="Attachment">
-        <xs:annotation>
-            <xs:documentation>Notes for server implementers:
+          </xs:sequence>
+          <xs:attribute name="id" type="xs:string" use="optional" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Attachment">
+    <xs:annotation>
+      <xs:documentation>Notes for server implementers:
 
                 The attachements MUST contain a human-readable version of all the crucial data
                 contained within the reports. This also includes all the data which may help to
@@ -692,55 +686,55 @@
                 You MAY also use the attachment to view a human-readable &quot;preview&quot; of the ELMO
                 data for the student.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
                         This identifier has been primarily established to enable internal references
                         to attachment from LOI's.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:simpleContent>
-                        <xs:extension base="xs:token">
-                            <xs:attribute name="type" type="xs:token" use="required">
-                                <xs:annotation>
-                                    <xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:token">
+              <xs:attribute name="type" type="xs:token" use="required">
+                <xs:annotation>
+                  <xs:documentation>
                                         Currently, the only type recognized is "internal"
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:attribute>
-                        </xs:extension>
-                    </xs:simpleContent>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="title" type="TokenWithOptionalLang" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>Title of the attachment, e.g. &quot;Transcript of records&quot;. May be provided in
+                </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="title" type="TokenWithOptionalLang" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Title of the attachment, e.g. &quot;Transcript of records&quot;. May be provided in
                         multiple languages. This is not required, but recommended - it might be used
                         by the clients, for example when displaying a list of attachments.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="type">
-                <xs:annotation>
-                    <xs:documentation>Type of the attachment. SHOULD be included if any type from the enclosed
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="type">
+        <xs:annotation>
+          <xs:documentation>Type of the attachment. SHOULD be included if any type from the enclosed
                         enumeration applies to the content of the attachment. If the none of the
                         predefined values apply then this element SHOULD either be skipped, or
                         &quot;Other&quot; value should be used.
 
                         More types MAY be added in the future. You SHOULD be prepared for that.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:token">
-                        <xs:enumeration value="Diploma"/>
-                        <xs:enumeration value="Diploma Supplement"/>
-                        <xs:enumeration value="Transcript of Records"/>
-                        <xs:enumeration value="EMREX transcript">
-                            <xs:annotation>
-                                <xs:documentation>This is similar to a Transcript of Records, with one big difference.
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="Diploma" />
+            <xs:enumeration value="Diploma Supplement" />
+            <xs:enumeration value="Transcript of Records" />
+            <xs:enumeration value="EMREX transcript">
+              <xs:annotation>
+                <xs:documentation>This is similar to a Transcript of Records, with one big difference.
 
                                     The &quot;EMREX Transcript&quot; is meant to include all the records within the
                                     transferred ELMO file (which can span over *multiple* institutions), that is, it
@@ -750,15 +744,15 @@
                                     signed) by a single institution, and should be located inside the `report`
                                     element.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="Micro Credential"/>
-                        <xs:enumeration value="Letter of Nomination"/>
-                        <xs:enumeration value="Certificate of Training"/>
-                        <xs:enumeration value="Learning Agreement"/>
-                        <xs:enumeration value="Other">
-                            <xs:annotation>
-                                <xs:documentation>This type can be used when none of the other currently defined types matches.
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Micro Credential" />
+            <xs:enumeration value="Letter of Nomination" />
+            <xs:enumeration value="Certificate of Training" />
+            <xs:enumeration value="Learning Agreement" />
+            <xs:enumeration value="Other">
+              <xs:annotation>
+                <xs:documentation>This type can be used when none of the other currently defined types matches.
                                     Using this type is more or less equivalent to not providing any type.
 
                                     Client implementers should be reminde, that the the number of types will grow.
@@ -767,23 +761,23 @@
                                     also might be caused by the fact the type X was added recently, and the server
                                     didn't discover it yet.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
-                <xs:annotation>
-                    <xs:documentation>An optional detailed description of the attachment (in multiple languages).
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
+        <xs:annotation>
+          <xs:documentation>An optional detailed description of the attachment (in multiple languages).
 
                         Avoid redundancy - you SHOULD NOT include the description if its value is
                         already included in the title element.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="content" type="TokenWithOptionalLang">
-                <xs:annotation>
-                    <xs:documentation>The content of the attachment encoded using a data URI scheme. E.g.
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="content" type="TokenWithOptionalLang">
+        <xs:annotation>
+          <xs:documentation>The content of the attachment encoded using a data URI scheme. E.g.
                         &quot;data:application/pdf;base64,iiNhz6QfDnnDybjHLBF2...&quot;
 
                         If you have several attachments of the same type with different languages, there
@@ -800,14 +794,14 @@
                         to dynamically generate the name for the file - the extension can be determined
                         from the content type use in the data URI.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer"/>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="LearningOpportunitySpecification">
-        <xs:annotation>
-            <xs:documentation>This describes a single &quot;branch&quot; of the &quot;LOS tree&quot;: One &quot;parent&quot; node along
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="LearningOpportunitySpecification">
+    <xs:annotation>
+      <xs:documentation>This describes a single &quot;branch&quot; of the &quot;LOS tree&quot;: One &quot;parent&quot; node along
                 with all its descendants (via the hasPart elements).
 
                 Each report element contains a set of such trees (a forest). For example, a
@@ -846,21 +840,21 @@
                 you will need to dynamically analyze the types of all the the nodes included in
                 the report and decide if the structure can be automatically imported.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="identifier">
-                <xs:annotation>
-                    <xs:documentation>For server implementers: Depending on your clients, you might be required to
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="identifier">
+        <xs:annotation>
+          <xs:documentation>For server implementers: Depending on your clients, you might be required to
                         supply specific identifier types (because clients expect them). E.g. some EMREX
                         clients expect the &quot;local&quot; identifier to be present.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:simpleContent>
-                        <xs:extension base="xs:token">
-                            <xs:attribute name="type" type="xs:token" use="required">
-                                <xs:annotation>
-                                    <xs:documentation>Some predefined type values include:
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:token">
+              <xs:attribute name="type" type="xs:token" use="required">
+                <xs:annotation>
+                  <xs:documentation>Some predefined type values include:
 
                                         &quot;local&quot; - the local unique identifier of the node. &quot;Unique&quot; means that the
                                             [node type, local identifier] tuple MUST uniquely identify this node
@@ -875,15 +869,15 @@
 
                                         You can also have any number of custom types.
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:attribute>
-                        </xs:extension>
-                    </xs:simpleContent>
-                </xs:complexType>
-            </xs:element>
-            <xs:element maxOccurs="unbounded" minOccurs="1" name="title" type="TokenWithOptionalLang">
-                <xs:annotation>
-                    <xs:documentation>The name(s) of the node (the title of a degree programme, or the name of a
+                </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="1" name="title" type="TokenWithOptionalLang">
+        <xs:annotation>
+          <xs:documentation>The name(s) of the node (the title of a degree programme, or the name of a
                         course, etc.).
 
                         Note for server implementers:
@@ -893,11 +887,11 @@
                         one, for example based on its ID and type. As a last resort, use an empty
                         string here.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="type">
-                <xs:annotation>
-                    <xs:documentation>The type of the node.
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="type">
+        <xs:annotation>
+          <xs:documentation>The type of the node.
 
                         Note for server implementers:
 
@@ -922,12 +916,12 @@
                         gracefully (treat it the same way as you would treat the node if the type
                         was not present at all).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:token">
-                        <xs:enumeration value="Degree Programme">
-                            <xs:annotation>
-                                <xs:documentation>A study programme. Finalizing a study programme ends with a degree (e.g.
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="Degree Programme">
+              <xs:annotation>
+                <xs:documentation>A study programme. Finalizing a study programme ends with a degree (e.g.
                                     Bachelor degree, Master degree, etc.).
 
                                     &quot;Degree programme&quot;s should not have a parent and should contain only &quot;Module&quot;s
@@ -935,30 +929,30 @@
                                     that in some rare cases, it is possible that they MAY also contain other
                                     &quot;Degree programme&quot;s.)
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="Module">
-                            <xs:annotation>
-                                <xs:documentation>A group or collection of courses.
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Module">
+              <xs:annotation>
+                <xs:documentation>A group or collection of courses.
 
                                     &quot;Module&quot;s may have a &quot;Degree programme&quot; parent, and should contain &quot;Course&quot;s
                                     only.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="Course">
-                            <xs:annotation>
-                                <xs:documentation>In EMREX we define &quot;Course&quot; as the *smallest* entity for the students to be
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Course">
+              <xs:annotation>
+                <xs:documentation>In EMREX we define &quot;Course&quot; as the *smallest* entity for the students to be
                                     able to gain ECTS credits from.
 
                                     A &quot;Course&quot; may have a &quot;Degree programme&quot; or a &quot;Module&quot; as a parent, and should
                                     contain &quot;Class&quot;es.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                        <xs:enumeration value="Class">
-                            <xs:annotation>
-                                <xs:documentation>A single education element a course consists of (like lecture, classes etc.).
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Class">
+              <xs:annotation>
+                <xs:documentation>A single education element a course consists of (like lecture, classes etc.).
 
                                     &quot;Class&quot;es should have a &quot;Course&quot; ancestor, and - if they contain any children -
                                     then these children should not have any type.
@@ -968,44 +962,44 @@
                                     class&quot;). The EMREX ELMO format does not currently provide any enumeration
                                     for such subtypes though.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element minOccurs="0" name="subjectArea" type="xs:token">
-                <xs:annotation>
-                    <xs:documentation>The Erasmus subject area code of the course.
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element minOccurs="0" name="subjectArea" type="xs:token">
+        <xs:annotation>
+          <xs:documentation>The Erasmus subject area code of the course.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="iscedCode" type="xs:token">
-                <xs:annotation>
-                    <xs:documentation>The ISCED-F code of the course or programme.
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="iscedCode" type="xs:token">
+        <xs:annotation>
+          <xs:documentation>The ISCED-F code of the course or programme.
 
                         ISCED-F codes define fields of education and training at the secondary,
                         post-secondary and tertiary levels of education. Details:
                         http://www.uis.unesco.org/Education/Documents/isced-fields-of-education-training-2013.pdf
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element minOccurs="0" name="url" type="xs:token">
-                <xs:annotation>
-                    <xs:documentation>The URL of the entity's web page (with the description of the course or
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="url" type="xs:token">
+        <xs:annotation>
+          <xs:documentation>The URL of the entity's web page (with the description of the course or
                         degree programme).
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
-                <xs:annotation>
-                    <xs:documentation>An optional plain-text description of the programme/course/class (in multiple
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
+        <xs:annotation>
+          <xs:documentation>An optional plain-text description of the programme/course/class (in multiple
                         languages).
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="descriptionHtml" type="SimpleHtmlStringWithOptionalLang">
-                <xs:annotation>
-                    <xs:documentation>An optional HTML description of the programme/course/class (in multiple
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="descriptionHtml" type="SimpleHtmlStringWithOptionalLang">
+        <xs:annotation>
+          <xs:documentation>An optional HTML description of the programme/course/class (in multiple
                         languages).
 
 
@@ -1030,73 +1024,73 @@
                         Remember to read the documentation on the SimpleHtmlStringWithOptionalLang
                         format! DO NOT JUST TRUST THAT THIS MARKUP IS SAFE.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="specifies">
-                <xs:annotation>
-                    <xs:documentation>Just a wrapper for learningOpportunityInstance (we're trying to be
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="specifies">
+        <xs:annotation>
+          <xs:documentation>Just a wrapper for learningOpportunityInstance (we're trying to be
                         ELMO-compatible).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="learningOpportunityInstance">
-                            <xs:annotation>
-                                <xs:documentation>While the &quot;learningOpportunitySpecification&quot; element describes a &quot;Degree
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="learningOpportunityInstance">
+              <xs:annotation>
+                <xs:documentation>While the &quot;learningOpportunitySpecification&quot; element describes a &quot;Degree
                                     programme&quot; (or a &quot;Course&quot;, etc.) by itself, this element tells us more of the
                                     relation between such programme (or course, etc.) and our &quot;learner&quot; (which
                                     includes student's grades, credits, and other achievements).
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:annotation>
-                                            <xs:documentation>A list of identifiers of this Learning Opportunity Instance.
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:documentation>A list of identifiers of this Learning Opportunity Instance.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:simpleContent>
-                                                <xs:extension base="xs:token">
-                                                    <xs:attribute name="type" type="xs:token" use="required">
-                                                        <xs:annotation>
-                                                            <xs:documentation>Some predefined type values include:
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:token">
+                          <xs:attribute name="type" type="xs:token" use="required">
+                            <xs:annotation>
+                              <xs:documentation>Some predefined type values include:
 
                                                                 &quot;ewp-loi-id&quot; - LOI identifier used in the EWP (Erasmus Without Paper) project.
                                                                     https://github.com/erasmus-without-paper/ewp-specs-api-courses#unique-identifiers
 
                                                                 You can also have any number of custom types.
                                                             </xs:documentation>
-                                                        </xs:annotation>
-                                                    </xs:attribute>
-                                                </xs:extension>
-                                            </xs:simpleContent>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="start" type="xs:date" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>The date on which the student started studying this learning opportunity
+                            </xs:annotation>
+                          </xs:attribute>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="start" type="xs:date" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>The date on which the student started studying this learning opportunity
                                                 (may contain a time zone).
 
                                                 A note for server implementers: Usually this will match the beginning of one of
                                                 the academic terms.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element name="date" type="xs:date" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>The date on which the student finished studying (may contain a time zone). It
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="date" type="xs:date" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>The date on which the student finished studying (may contain a time zone). It
                                                 doesn't necessarilly need to match the end of the academic term. Prefferably,
                                                 this should be the date when the student has passed his final exam.
 
                                                 A note for server implementers: If the exact date cannot be determined, please
                                                 try to include an approximate date, e.g. the last day of the academic term.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element name="academicTerm" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>Describes the academic term in which the course took place.
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="academicTerm" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Describes the academic term in which the course took place.
 
                                                 A note for server implementers: You SHOULD include this element for &quot;Course&quot;-type
                                                 learning opportunities (EMREX's &quot;Course&quot; entities *always* span over a single
@@ -1104,34 +1098,34 @@
                                                 Programme&quot;s, or any other learning opportunities which span over multiple
                                                 terms.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element maxOccurs="unbounded" name="title" type="TokenWithOptionalLang">
-                                                    <xs:annotation>
-                                                        <xs:documentation>The displayed name of the academic term, in multiple languages. Servers SHOULD
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" name="title" type="TokenWithOptionalLang">
+                          <xs:annotation>
+                            <xs:documentation>The displayed name of the academic term, in multiple languages. Servers SHOULD
                                                             provide at least the name in English.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <xs:element name="start" type="xs:date">
-                                                    <xs:annotation>
-                                                        <xs:documentation>SHOULD match the first day of the academic term (may contain a time zone).
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element name="start" type="xs:date">
+                          <xs:annotation>
+                            <xs:documentation>SHOULD match the first day of the academic term (may contain a time zone).
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <xs:element name="end" type="xs:date">
-                                                    <xs:annotation>
-                                                        <xs:documentation>SHOULD match the last day of the academic term (may contain a time zone).
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element name="end" type="xs:date">
+                          <xs:annotation>
+                            <xs:documentation>SHOULD match the last day of the academic term (may contain a time zone).
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="status" minOccurs="0" maxOccurs="1">
-                                        <xs:annotation>
-                                            <xs:documentation>The status of this LOI. It is STRONGLY RECOMMENDED for all server implementers
+                          </xs:annotation>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="status" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                      <xs:documentation>The status of this LOI. It is STRONGLY RECOMMENDED for all server implementers
                                                 to include this element explicitly (even if the server does not ever include
                                                 LOIs other than &quot;passed&quot; in this particular context).
 
@@ -1143,36 +1137,36 @@
                                                 status values are needed, then a new element (e.g. `status2`) will be
                                                 introduced instead (while `status` will probably get deprecated).
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:simpleType>
-                                            <xs:restriction base="xs:token">
-                                                <xs:enumeration value="passed">
-                                                    <xs:annotation>
-                                                        <xs:documentation>Indicates that this LOI has been passed by the student. Once the status is
+                    </xs:annotation>
+                    <xs:simpleType>
+                      <xs:restriction base="xs:token">
+                        <xs:enumeration value="passed">
+                          <xs:annotation>
+                            <xs:documentation>Indicates that this LOI has been passed by the student. Once the status is
                                                             &quot;passed&quot;, it SHOULD NOT change to any other status.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:enumeration>
-                                                <xs:enumeration value="failed">
-                                                    <xs:annotation>
-                                                        <xs:documentation>Indicates that the student permanently failed to pass this LOI. Once the
+                          </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="failed">
+                          <xs:annotation>
+                            <xs:documentation>Indicates that the student permanently failed to pass this LOI. Once the
                                                             status is &quot;failed&quot;, it SHOULD NOT change to any other status.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:enumeration>
-                                                <xs:enumeration value="in-progress">
-                                                    <xs:annotation>
-                                                        <xs:documentation>Indicates that the student has started this LOI, but has not completed it yet.
+                          </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="in-progress">
+                          <xs:annotation>
+                            <xs:documentation>Indicates that the student has started this LOI, but has not completed it yet.
                                                             Eventually, this status SHOULD change to &quot;passed&quot; or &quot;failed&quot;.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:enumeration>
-                                            </xs:restriction>
-                                        </xs:simpleType>
-                                    </xs:element>
-                                    <xs:element name="gradingSchemeLocalId" type="xs:token" maxOccurs="1" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>RECOMMENDED. Identifier of the grading scheme used in `resultLabel` and
+                          </xs:annotation>
+                        </xs:enumeration>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:element>
+                  <xs:element name="gradingSchemeLocalId" type="xs:token" maxOccurs="1" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>RECOMMENDED. Identifier of the grading scheme used in `resultLabel` and
                                                 `resultDistribution` below.
 
                                                 This identifier is provided by the institution which has generated this report,
@@ -1181,59 +1175,59 @@
                                                 grading scheme descriptions in the `gradingScheme` children of the `report`
                                                 element.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element name="resultLabel" type="xs:token" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>The final grade awarded for the student. This SHOULD contain the same value as
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="resultLabel" type="xs:token" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>The final grade awarded for the student. This SHOULD contain the same value as
                                                 the one printed in the official documents in the server's country.
 
                                                 A note for client implementers: You MUST be prepared for the resultLabel
                                                 to NOT be present. Some servers may not actually keep the grades, so they
                                                 may not be able to include them here.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element name="shortenedGrading" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>Optional. Might be provided by some servers.
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="shortenedGrading" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Optional. Might be provided by some servers.
 
                                                 This element may be used by clients as an indicator of *how well* the
                                                 student was graded when compared to other students. The three values don't
                                                 need to be very exact (one decimal place should be more than enough), but
                                                 they SHOULD sum up to 100.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="percentageLower" type="xs:decimal">
-                                                    <xs:annotation>
-                                                        <xs:documentation>The percentage of students of the same course who got a lower grade than
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="percentageLower" type="xs:decimal">
+                          <xs:annotation>
+                            <xs:documentation>The percentage of students of the same course who got a lower grade than
                                                             our learner (this includes the students which have failed the course).
                                                             A decimal number between 0 and 100 (though 100 is never reached).
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <xs:element name="percentageEqual" type="xs:decimal">
-                                                    <xs:annotation>
-                                                        <xs:documentation>The percentage of students of the same course who got exactly the same grade as
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element name="percentageEqual" type="xs:decimal">
+                          <xs:annotation>
+                            <xs:documentation>The percentage of students of the same course who got exactly the same grade as
                                                             our learner.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <xs:element name="percentageHigher" type="xs:decimal">
-                                                    <xs:annotation>
-                                                        <xs:documentation>The percentage of students of the same course who got a higher grade than
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element name="percentageHigher" type="xs:decimal">
+                          <xs:annotation>
+                            <xs:documentation>The percentage of students of the same course who got a higher grade than
                                                             our learner.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="resultDistribution" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>Optional. Might be provided by some servers.
+                          </xs:annotation>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="resultDistribution" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Optional. Might be provided by some servers.
 
                                                 At first, this element might seem similar to the shortenedGrading element, but
                                                 it serves a different purpose. It describes a histogram of results achieved by
@@ -1245,43 +1239,43 @@
                                                 If provided, then it should contain the distribution of results of all the
                                                 students (including the ones that have failed the course).
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element maxOccurs="unbounded" name="category">
-                                                    <xs:annotation>
-                                                        <xs:documentation>This describes a single range within the histogram.
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" name="category">
+                          <xs:annotation>
+                            <xs:documentation>This describes a single range within the histogram.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                    <xs:complexType>
-                                                        <xs:attribute name="label" type="xs:token" use="required">
-                                                            <xs:annotation>
-                                                                <xs:documentation>The label of the histogram range. Should correspond to the grading scheme
+                          </xs:annotation>
+                          <xs:complexType>
+                            <xs:attribute name="label" type="xs:token" use="required">
+                              <xs:annotation>
+                                <xs:documentation>The label of the histogram range. Should correspond to the grading scheme
                                                                     which have been used. E.g. &quot;C&quot;, or &quot;20-30&quot;. If possible, the label should
                                                                     be understandable in any language. If not, you should try to use English.
                                                                 </xs:documentation>
-                                                            </xs:annotation>
-                                                        </xs:attribute>
-                                                        <xs:attribute name="count" type="xs:nonNegativeInteger" use="required">
-                                                            <xs:annotation>
-                                                                <xs:documentation>The number of students whose grades fall within that category.
+                              </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="count" type="xs:nonNegativeInteger" use="required">
+                              <xs:annotation>
+                                <xs:documentation>The number of students whose grades fall within that category.
                                                                 </xs:documentation>
-                                                            </xs:annotation>
-                                                        </xs:attribute>
-                                                    </xs:complexType>
-                                                </xs:element>
-                                                <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
-                                                    <xs:annotation>
-                                                        <xs:documentation>Optional additional description of the histogram (in multiple languages).
+                              </xs:annotation>
+                            </xs:attribute>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
+                          <xs:annotation>
+                            <xs:documentation>Optional additional description of the histogram (in multiple languages).
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="credit" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:annotation>
-                                            <xs:documentation>This describes various credit types which student has achieved by completing
+                          </xs:annotation>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="credit" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:documentation>This describes various credit types which student has achieved by completing
                                                 this module/course/class.
 
                                                 At least ECTS credits SHOULD be included.
@@ -1291,12 +1285,12 @@
                                                 completing a course, he/she should not be given the same credits &quot;again&quot; for
                                                 completing the degree programme which this course has been a part of.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="scheme" type="xs:token">
-                                                    <xs:annotation>
-                                                        <xs:documentation>Currently there is only one predefined scheme you can have here:
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="scheme" type="xs:token">
+                          <xs:annotation>
+                            <xs:documentation>Currently there is only one predefined scheme you can have here:
 
                                                             ects - if the scheme is &quot;ects&quot;, then the value element MUST contain the number
                                                                 of ECTS credits awarded for our learner for completing this learning
@@ -1304,38 +1298,38 @@
 
                                                             You can also include any number of other credits with custom schemes.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <!-- DEPRECATED - will be removed in Version 2-->
-                                                <xs:element minOccurs="0" name="level">
-                                                    <xs:annotation>
-                                                        <xs:documentation>This one was never properly documented, and is planned to be deprecated soon.
+                          </xs:annotation>
+                        </xs:element>
+                        <!-- DEPRECATED - will be removed in Version 2-->
+                        <xs:element minOccurs="0" name="level">
+                          <xs:annotation>
+                            <xs:documentation>This one was never properly documented, and is planned to be deprecated soon.
                                                             Servers and clients who plan to use it SHOULD first refer to these threads:
 
                                                             https://github.com/emrex-eu/elmo-schemas/issues/26
                                                             https://github.com/emrex-eu/elmo-schemas/issues/33
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                    <xs:simpleType>
-                                                        <xs:restriction base="xs:token">
-                                                            <xs:enumeration value="Bachelor"/>
-                                                            <xs:enumeration value="Master"/>
-                                                            <xs:enumeration value="PhD"/>
-                                                        </xs:restriction>
-                                                    </xs:simpleType>
-                                                </xs:element>
-                                                <xs:element minOccurs="0" name="value" type="xs:decimal">
-                                                    <xs:annotation>
-                                                        <xs:documentation>The number of credits acquired.
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                              <xs:enumeration value="Bachelor" />
+                              <xs:enumeration value="Master" />
+                              <xs:enumeration value="PhD" />
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                        <xs:element minOccurs="0" name="value" type="xs:decimal">
+                          <xs:annotation>
+                            <xs:documentation>The number of credits acquired.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="level" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:annotation>
-                                            <xs:documentation>This describes various levels of education.
+                          </xs:annotation>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="level" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:documentation>This describes various levels of education.
 
                                                 Here, issuers of ELMO can describe types of education levels.
 
@@ -1345,34 +1339,34 @@
 
                                                 Supported types are described in the type section below.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="type" type="xs:token">
-                                                    <xs:annotation>
-                                                        <xs:documentation>Currently supported types are:
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="type" type="xs:token">
+                          <xs:annotation>
+                            <xs:documentation>Currently supported types are:
                                                             - EQF (European Qualification Framework)
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <xs:element minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
-                                                    <xs:annotation>
-                                                        <xs:documentation>An optional detailed description of the the type of level that is being supplied. 
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element minOccurs="0" name="description" type="PlaintextMultilineStringWithOptionalLang">
+                          <xs:annotation>
+                            <xs:documentation>An optional detailed description of the the type of level that is being supplied. 
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                                <xs:element minOccurs="0" name="value" type="xs:token">
-                                                    <xs:annotation>
-                                                        <xs:documentation>The level value.
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element minOccurs="0" name="value" type="xs:token">
+                          <xs:annotation>
+                            <xs:documentation>The level value.
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="languageOfInstruction" type="xs:token" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>Recommended, especially for courses and/or classes. An ISO 639-1 code of the
+                          </xs:annotation>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="languageOfInstruction" type="xs:token" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Recommended, especially for courses and/or classes. An ISO 639-1 code of the
                                                 language which has been used as the primary language for teaching the learner
                                                 during the classes. E.g. &quot;pl&quot; if the course was instructed/conducted in Polish.
 
@@ -1380,157 +1374,156 @@
                                                 languages were used, attempt to select the primary one. If you cannot select a
                                                 single primary language, then you MUST NOT include this element at all.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element name="engagementHours" type="xs:decimal" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>Recommended. For courses or classes. The number of hours the student had spent
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="engagementHours" type="xs:decimal" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Recommended. For courses or classes. The number of hours the student had spent
                                                 on attending the classes.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element name="attachments" minOccurs="0" maxOccurs="1">
-                                        <xs:annotation>
-                                            <xs:documentation>
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="attachments" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                      <xs:documentation>
                                                 List the attachments connected to this specific LOI.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="ref" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-                                                    <xs:annotation>
-                                                        <xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="ref" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                          <xs:annotation>
+                            <xs:documentation>
                                                             Reference to the attachment.identifier
                                                         </xs:documentation>
-                                                    </xs:annotation>
-                                                </xs:element>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="grouping" minOccurs="0">
-                                        <xs:complexType>
-                                            <xs:simpleContent>
-                                                <xs:extension base="xs:string">
-                                                    <xs:attribute name="typeref" type="xs:string">
-                                                        <xs:annotation>
-                                                            <xs:documentation>A reference to the groups.id
-                                                            </xs:documentation>
-                                                        </xs:annotation>
-                                                    </xs:attribute>
-                                                    <xs:attribute name="idref" type="xs:string">
-                                                        <xs:annotation>
-                                                            <xs:documentation>A reference to the groups.group.id
-                                                            </xs:documentation>
-                                                        </xs:annotation>
-                                                    </xs:attribute>
-                                                </xs:extension>
-                                            </xs:simpleContent>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="extension" type="CustomExtensionsContainer" minOccurs="0"/>
-                                    <xs:element name="diplomaSupplement" type="DiplomaSupplement" minOccurs="0">
-                                        <xs:annotation>
-                                            <xs:documentation>Each learningOpportunityInstance of type Degree Programme can include a Diploma Supplement, see the DiplomaSupplement type for details.
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
+                          </xs:annotation>
                         </xs:element>
-                        <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer"/>
-                    </xs:sequence>
-                </xs:complexType>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="grouping" minOccurs="0">
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                          <xs:attribute name="typeref" type="xs:string">
+                            <xs:annotation>
+                              <xs:documentation>A reference to the groups.id
+                                                            </xs:documentation>
+                            </xs:annotation>
+                          </xs:attribute>
+                          <xs:attribute name="idref" type="xs:string">
+                            <xs:annotation>
+                              <xs:documentation>A reference to the groups.group.id
+                                                            </xs:documentation>
+                            </xs:annotation>
+                          </xs:attribute>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="extension" type="CustomExtensionsContainer" minOccurs="0" />
+                  <xs:element name="diplomaSupplement" type="DiplomaSupplement" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Each learningOpportunityInstance of type Degree Programme can include a Diploma Supplement, see the DiplomaSupplement type for details.
+                                            </xs:documentation>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
             </xs:element>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="hasPart">
-                <xs:annotation>
-                    <xs:documentation>Just a wrapper for learningOpportunitySpecification (we're trying to be
+            <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="hasPart">
+        <xs:annotation>
+          <xs:documentation>Just a wrapper for learningOpportunitySpecification (we're trying to be
                         ELMO-compatible).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="learningOpportunitySpecification" type="LearningOpportunitySpecification">
-                            <xs:annotation>
-                                <xs:documentation>Each hasPart contains exactly one learningOpportunitySpecification, which
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="learningOpportunitySpecification" type="LearningOpportunitySpecification">
+              <xs:annotation>
+                <xs:documentation>Each hasPart contains exactly one learningOpportunitySpecification, which
                                     contains one child node of our tree. Every node may have an unlimited number
                                     of hasPart/learningOpportunitySpecification elements.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
+              </xs:annotation>
             </xs:element>
-            <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer"/>
-        </xs:sequence>
-    </xs:complexType>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" name="extension" type="CustomExtensionsContainer" />
+    </xs:sequence>
+  </xs:complexType>
 
-    <xs:complexType name="DiplomaSupplement">
-        <xs:annotation>
-            <xs:documentation>The Diploma Supplement (DS) is a document accompanying a higher education diploma, providing a standardised description of the nature, level, context, content and status of the studies completed by its holder.
+  <xs:complexType name="DiplomaSupplement">
+    <xs:annotation>
+      <xs:documentation>The Diploma Supplement (DS) is a document accompanying a higher education diploma, providing a standardised description of the nature, level, context, content and status of the studies completed by its holder.
 
             Details:
             http://ec.europa.eu/education/resources/diploma-supplement_en
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="version" type="xs:token" default="2018">
-                <xs:annotation>
-                    <xs:documentation>The version number refers to the official rules for what a DS should include.  As these rules rarely change, it was agreed the version to be the year the rules this document adheres to were introduced (1997, 2007, 2018).  As of creating this schema, the last change was introduced in 2018, so this is the default version, unless specified otherwise.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="issueDate" type="xs:date">
-                <xs:annotation>
-                    <xs:documentation>The date when the DS was generated. Example values: &quot;2015-08-01&quot;, &quot;2017-01-31&quot;.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="introduction">
-                <xs:annotation>
-                    <xs:documentation>The standard introduction which in English starts with "This Diploma Supplement model was developed by the European Commission (...)"
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="section" type="DiplomaSupplementSection" minOccurs="1" maxOccurs="unbounded">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" ref="ds:Signature">
-                <xs:annotation>
-                    <xs:documentation>The DS itself can be digitally signed, e.g. if the DS issuer is not the same entity as the one issuing the ELMO document.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-        <xs:attribute ref="xml:lang" use="optional">
-            <xs:annotation>
-                <xs:documentation>The language the DS has been issued in, of type xml:lang as defined in BCP 47.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-
-    <xs:complexType name="DiplomaSupplementSection">
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="version" type="xs:token" default="2018">
         <xs:annotation>
-            <xs:documentation>The section element in the DS refers to the official section numbers (1, 2...), and can include other sections (1.1, 1.2, 2.1, 2.2...)
-            </xs:documentation>
+          <xs:documentation>The version number refers to the official rules for what a DS should include.  As these rules rarely change, it was agreed the version to be the year the rules this document adheres to were introduced (1997, 2007, 2018).  As of creating this schema, the last change was introduced in 2018, so this is the default version, unless specified otherwise.
+                    </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
-            <xs:element name="title" type="xs:token">
-                <xs:annotation>
-                    <xs:documentation>The section title SHOULD match the official rules for DS.
+      </xs:element>
+      <xs:element name="issueDate" type="xs:date">
+        <xs:annotation>
+          <xs:documentation>The date when the DS was generated. Example values: &quot;2015-08-01&quot;, &quot;2017-01-31&quot;.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="content" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>The content of the section.  The element is optional in cases where a section only has subsections (like top level sections might have).
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="introduction">
+        <xs:annotation>
+          <xs:documentation>The standard introduction which in English starts with "This Diploma Supplement model was developed by the European Commission (...)"
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:simpleContent>
-                        <xs:extension base="xs:token">
-                            <xs:attribute name="type" type="xs:token" default="text/plain">
-                                <xs:annotation>
-                                    <xs:documentation>The format (media type), as defined by IANA.  Some predefined type values include:
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="section" type="DiplomaSupplementSection" minOccurs="1" maxOccurs="unbounded"></xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" ref="ds:Signature">
+        <xs:annotation>
+          <xs:documentation>The DS itself can be digitally signed, e.g. if the DS issuer is not the same entity as the one issuing the ELMO document.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute ref="xml:lang" use="optional">
+      <xs:annotation>
+        <xs:documentation>The language the DS has been issued in, of type xml:lang as defined in BCP 47.
+                </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="DiplomaSupplementSection">
+    <xs:annotation>
+      <xs:documentation>The section element in the DS refers to the official section numbers (1, 2...), and can include other sections (1.1, 1.2, 2.1, 2.2...)
+            </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="title" type="xs:token">
+        <xs:annotation>
+          <xs:documentation>The section title SHOULD match the official rules for DS.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="content" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The content of the section.  The element is optional in cases where a section only has subsections (like top level sections might have).
+                    </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:token">
+              <xs:attribute name="type" type="xs:token" default="text/plain">
+                <xs:annotation>
+                  <xs:documentation>The format (media type), as defined by IANA.  Some predefined type values include:
 
                                         &quot;text/plain&quot; - plain text
 
@@ -1541,35 +1534,35 @@
 
                                         Note: If HTML, XML or similar formatting are used, the content MUST be enclosed in &lt;![CDATA[ (...) ]]&gt;
                                     </xs:documentation>
-                                </xs:annotation>
-                            </xs:attribute>
-                        </xs:extension>
-                    </xs:simpleContent>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="additionalInformation" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>Any additional information, including possible references to other sections.
-                    </xs:documentation>
                 </xs:annotation>
-            </xs:element>
-            <xs:element name="attachment" type="Attachment" maxOccurs="unbounded" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>Please note that attachments can be included in multiple places. This is the
+              </xs:attribute>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="additionalInformation" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Any additional information, including possible references to other sections.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="attachment" type="Attachment" maxOccurs="unbounded" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Please note that attachments can be included in multiple places. This is the
                         place for those attachments which are related to this particular section.
 
                         Read the description of the Attachment type for further information.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="section" type="DiplomaSupplementSection" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-        <xs:attribute name="number" use="required">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:pattern value="[0-9\.]+"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:complexType>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="section" type="DiplomaSupplementSection" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="number" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="[0-9\.]+" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Institution-specific characteristic (to be added to the “Issuer” of ELMO-structure) - Address

Remarks to the additional institution-specific characteristic:
SfH needs the address of the diploma issuer to get a unique identification of the issuer (school).