### PR TITLE
ISSUE-95: Added the suggested XML-code to the LOS-element insted of R…

### DIFF
--- a/schema.xsd
+++ b/schema.xsd
@@ -1114,6 +1114,8 @@
           <xs:restriction base="xs:string">
             <xs:enumeration value="Diploma"/>
             <xs:enumeration value="Certificate"/>
+            <xs:enumeration value="Enrolment"/>
+            <xs:enumeration value="Admission"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>

--- a/schema.xsd
+++ b/schema.xsd
@@ -1106,7 +1106,7 @@
       </xs:element>
       <xs:element minOccurs="0" name="documentType">
         <xs:annotation>
-          <xs:documentation>Defines the type of the document which can be either Diploma or Certificate.
+          <xs:documentation>Defines the type of the document. Can be Diploma, Certificate, Enrolment or Admission.
             This element is not required. When left empty the document will be considered a Diploma.
           </xs:documentation>
         </xs:annotation>

--- a/schema.xsd
+++ b/schema.xsd
@@ -1104,6 +1104,19 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element minOccurs="0" name="documentType">
+        <xs:annotation>
+          <xs:documentation>Defines the type of the document which can be either Diploma or Certificate.
+            This element is not required. When left empty the document will be considered a Diploma.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="Diploma"/>
+            <xs:enumeration value="Certificate"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
       <xs:element name="specifies">
         <xs:annotation>
           <xs:documentation>


### PR DESCRIPTION
Attempting to solve issue 95 https://github.com/emrex-eu/elmo-schemas/issues/95

I added the suggested XML-code to LOS instead of report. I did this as the issue suggest that this is additional information to the type "degree-programme" and that is specified on the LOS-level, not the report-level. 

I feel that the document types should be discussed in the Emrex EC. Certificate feels like a too large an umbrella term to be used in such a narrow way (only partially completed degree programmes). When talking to Geir, I suggested "Transcript of Records", however that term feels too "old" and more like paper logic. 

I also feel that the documentation must specify that these terms are only used in this specific context, however i would like some help with writing this documentation. 